### PR TITLE
[JFG-400]: More reliable check for agents/kernels running

### DIFF
--- a/src/main/resources/com/griddynamics/jagger/jenkins/plugin/script/agent.checking.script
+++ b/src/main/resources/com/griddynamics/jagger/jenkins/plugin/script/agent.checking.script
@@ -1,8 +1,8 @@
 
 echo "Checking Agent ${server-address}"
-JOUT=$(ssh${ssh-key-path} ${user-name}@${server-address} "ps axwww | grep AgentStarter | wc -l")
+JOUT=$(ssh${ssh-key-path} ${user-name}@${server-address} "pgrep -f AgentStarter")
 
-	if [ "$JOUT" -le 2 ] ; then
+	if [ -z "$JOUT" ] ; then
 		echo "No AgentStarter running on ${server-address}"
 		exit $JOUT
 	fi

--- a/src/main/resources/com/griddynamics/jagger/jenkins/plugin/script/kernel.checking.script
+++ b/src/main/resources/com/griddynamics/jagger/jenkins/plugin/script/kernel.checking.script
@@ -1,8 +1,8 @@
 
 echo "Checking Kernel ${server-address}"
-JOUT=$(ssh${ssh-key-path} ${user-name}@${server-address} "ps axwww | grep JaggerLauncher | wc -l")
+JOUT=$(ssh${ssh-key-path} ${user-name}@${server-address} "pgrep -f JaggerLauncher")
 
-	if [ "$JOUT" -le 2 ] ; then
+	if [ -z "$JOUT" ] ; then
 		echo "No JaggerLauncher running on ${server-address}"
 		exit $JOUT
 	fi

--- a/src/main/resources/com/griddynamics/jagger/jenkins/plugin/script/starting.nodes.script
+++ b/src/main/resources/com/griddynamics/jagger/jenkins/plugin/script/starting.nodes.script
@@ -3,7 +3,7 @@ ${if starting-kernels-agents}
 echo "Starting Kernels/Agents"
 ${starting-kernels-agents}
 
-echo "Checking if Kernels/Agents runs"
+echo "Checking if Kernels/Agents run"
 sleep 10
 
 ${check-kernels-agents}


### PR DESCRIPTION
This refers to patch for the same ticket in Jagger project.
"pgrep" allows to get PID of process filtering out "grep" itself.
+tiny grammar fix
